### PR TITLE
ページ下部のFacebookのリンクシェアURLを2015のないものへ変更

### DIFF
--- a/otsc/index.html
+++ b/otsc/index.html
@@ -463,7 +463,7 @@
                     <div class="col-lg-10 col-lg-offset-1 text-center">
                         <ul class="list-inline">
                             <li>
-                                <a href="http://www.facebook.com/sharer/sharer.php?u=http%3a%2f%2fgoo%2egl%2fT20YT7"><i class="fa fa-facebook fa-fw fa-3x"></i></a>
+                                <a href="http://www.facebook.com/sharer/sharer.php?u=http://histudy.github.io/otsc/"><i class="fa fa-facebook fa-fw fa-3x"></i></a>
                             </li>
                             <li>
                                 <a href="https://twitter.com/intent/tweet?text=%e3%82%aa%e3%83%bc%e3%83%97%e3%83%b3%e3%83%86%e3%83%83%e3%82%af%e3%83%bb%e3%82%b7%e3%83%a7%e3%83%bc%e3%82%b1%e3%83%bc%e3%82%b9%e3%83%bb%e3%83%92%e3%83%a1%e3%82%b8%202015&url=https%3a%2f%2fgoo%2egl%2fSP6s1C&via=himeji_study"><i class="fa fa-twitter fa-fw fa-3x"></i></a>


### PR DESCRIPTION
リンクのGETパラメータにURLが埋め込まれていたので変更しました